### PR TITLE
usgs: resume download where it stopped

### DIFF
--- a/lib/usgs.py
+++ b/lib/usgs.py
@@ -30,6 +30,7 @@ specific language governing rights and limitations under the License.
 
 import datetime
 import os
+import random
 import re
 
 import requests
@@ -45,13 +46,18 @@ from numcodecs import Blosc
 def fetch_usgs(fld, a, b):
 
     for d1, d2 in _date_interval_range(a, b):
-
+        dst = os.path.join(fld, f'{d1[0]:04d}-{d1[1]:02d}-{d1[2]:02d}.csv')
+        if os.path.exists(dst):
+            print("skip " + dst)
+            continue
         r = requests.get(
             'https://earthquake.usgs.gov/fdsnws/event/1/query?format=csv&'
             f'starttime={d1[0]:04d}-{d1[1]:02d}-{d1[2]:02d}&endtime={d2[0]:04d}-{d2[1]:02d}-{d2[2]:02d}'
         )
-        with open(os.path.join(fld, f'{d1[0]:04d}-{d1[1]:02d}-{d1[2]:02d}.csv'), 'w', encoding = 'utf-8') as f:
+        tmp = dst + '-{:08d}'.format(random.randint(0, 9999999))
+        with open(tmp, 'w', encoding = 'utf-8') as f:
             f.write(r.text)
+        os.rename(tmp, dst)
 
 def reencode_usgs(src_fld, target):
 

--- a/prepare_usgs.py
+++ b/prepare_usgs.py
@@ -39,7 +39,8 @@ from lib.usgs import fetch_usgs, reencode_usgs
 
 def run():
 
-    os.mkdir('data_usgs')
+    if not os.path.exists('data_usgs'):
+        os.mkdir('data_usgs')
     fetch_usgs('data_usgs', (2010, 1, 1), (2020, 1, 1))
     reencode_usgs('data_usgs', 'data_usgs.zarr')
 


### PR DESCRIPTION
Eye-candy!

Just like a

![](https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/Moscow_SHM_asv2019-06_img17.jpg/192px-Moscow_SHM_asv2019-06_img17.jpg)

with time travel!

---- 

Fetching usgs data might take a while. If download is interrupted, the
user might need to fetch anew.

This change allows to resume a download, hence saving download time (and
bandwidth). To refresh, just remove all downloaded files.